### PR TITLE
fix: add missing project dependency

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -19,4 +19,4 @@ Compiling
 
 To compile OCLToys, you have to use cmake (http://www.cmake.org). OCLToys haave
 the following dependencies: OpenCL (http://www.khronos.org/opencl), OpenGL (http://www.khronos.org/opengl),
-Boost Library (http://www.boost.org) and GLUT Library (http://freeglut.sourceforge.net).
+Boost Library (http://www.boost.org), OpenCL C++ headers (https://github.com/KhronosGroup/OpenCL-CLHPP) and GLUT Library (http://freeglut.sourceforge.net).


### PR DESCRIPTION
At least Debian has a separate package for OpenCL C++ header files. The Khronos Group also has a separate repository for these headers (https://github.com/KhronosGroup/OpenCL-CLHPP).